### PR TITLE
@On2D and @On2Nd removed

### DIFF
--- a/docs/manual/determinism-checker.tex
+++ b/docs/manual/determinism-checker.tex
@@ -181,8 +181,8 @@ A standard polymorphic annotation
 
 \noindent
 can express the first and third versions of each routine, but not the
-second one.  The \refqualclass{checker/determinism/qual}{Ond2D} and
-\refqualclass{checker/determinism/qual}{Ond2Nd} annotations enable
+second one.  The \refqualclass{checker/determinism/qual}{PolyDet}\<("down")> and
+\refqualclass{checker/determinism/qual}{PolyDet}\<("up")> annotations enable
 expressing the method behavior:
 
 \begin{Verbatim}


### PR DESCRIPTION
Hi,
I think `@On2D` and `@On2Nd` are removed in the newer version of documentation in comparison to previous one that was shared on [checker google group](https://groups.google.com/forum/#!topic/checker-framework-gsoc/KmoZ9usbQao).