### PR TITLE
Fix typo in determinism manaul

### DIFF
--- a/docs/manual/determinism-checker.tex
+++ b/docs/manual/determinism-checker.tex
@@ -160,7 +160,7 @@ several enhancements to standard polymorphic qualifiers.
   \<@OrderNonDet> is changed to a higher qualifier that is a supertype of it.
 \end{description}
 
-Ordinarily, every occurrence of \<@PolyDet> is instantiated at the same
+Ordinarily, every occurrence of \<@PolyDet> is instantiated to the same
 type.  Sometimes this does not capture the desired behavior.  For instance,
 there should be three versions of the \<List.add> and \<List.hashCode> routines:
 


### PR DESCRIPTION
Changed "instantiated at the same type" to "instantiated to the same type" which I believe is the intended meaning.