### PR TITLE
Added tests for Array bugs

### DIFF
--- a/checker/tests/determinism/TestArrays.java
+++ b/checker/tests/determinism/TestArrays.java
@@ -4,6 +4,31 @@ import java.util.*;
 import org.checkerframework.checker.determinism.qual.*;
 
 class TestArrays {
+    // Tests whether array parameters have correct defaults when passed.
+    void testArrParam() {
+        @PolyDet int @PolyDet [] arr = new @PolyDet int @PolyDet [0];
+        takeArry(arr);
+    }
+
+    // Tests whether array return values have correct defaults.
+    void testArrRet() {
+        // :: error: (assignment.type.incompatible)
+        @Det int i = returnArr()[0];
+    }
+    // Tests whether returned arrays have correct defaults within methods.
+    int[] testArrRetInternal() {
+        @PolyDet int @PolyDet [] arr = new @PolyDet int @PolyDet [0];
+        // This should fail if @Det int [] @PolyDet is expected, which it
+        // should't be.
+        return new int[0];
+    }
+
+    int[] returnArr() {
+        return new int[] {0};
+    }
+
+    void takeArr(int[] a) {}
+
     void testArr(int[] a) {
         // :: error: (assignment.type.incompatible)
         @Det int i = a[0];


### PR DESCRIPTION
Added (failing) tests for the defaults for arrays externally. Although they are internally treated as `@PolyDet type @PolyDet[]`, these tests show that when calling methods, the default is still `@Det type @PolyDet`, which causes a mismatch between the strength the method requires of callers and how much it uses internally.

Also adds similar tests for default array return types.