### PR TITLE
Added test for array sorting with comparators

### DIFF
--- a/checker/tests/determinism/TestArraysSort.java
+++ b/checker/tests/determinism/TestArraysSort.java
@@ -12,4 +12,18 @@ public class TestArraysSort {
         Arrays.sort(a);
         System.out.println(a[0]);
     }
+
+    void testSort2(@Det Integer @OrderNonDet [] a) {
+        // :: error: (argument.type.incompatible)
+        System.out.println(a[0]);
+        IntComparator c = new IntComparator();
+        Arrays.sort(a, c);
+        System.out.println(a[0]);
+    }
+
+    class IntComparator implements Comparator<@PolyDet Integer> {
+        public int compare(Integer i1, Integer i2) {
+            return 0;
+        }
+    }
 }


### PR DESCRIPTION
This adds a test for the Comparator based Arrays.sort method, which currently seems to have issues. It doesn't do the type refinement like the other sort methods and it doesn't accept the array as a parameter for some reason.

The Comparator has a weird type declaration with `@PolyDet Integer` because doing anything else causes other issues with typing.