### PR TITLE
Added tests for Issue7

### DIFF
--- a/checker/tests/determinism/Issue7.java
+++ b/checker/tests/determinism/Issue7.java
@@ -1,0 +1,20 @@
+package determinism;
+
+import java.util.*;
+import org.checkerframework.checker.determinism.qual.*;
+
+class Issue7 {
+    // Tests whether this.method is treated correctly.
+    int testDotThis() {
+        return this.returnZero();
+    }
+
+    // Tests whether super.method is treated correctly.
+    String testDotSuper() {
+        return super.toString();
+    }
+
+    int returnZero() {
+        return 0;
+    }
+}


### PR DESCRIPTION
Adds tests for issue #7 where the dot operator adds issues when it shouldn't. This includes examples with both `this.` and `super.` which seem to be part of the same bug.