### PR TITLE
Disallow @Det HashSet

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -2,7 +2,7 @@ ext {
     // See instructions for updating jdk8.jar at
     // https://github.com/typetools/annotated-libraries/blob/master/README.md .
     // Set jdkShaHash to 'local' to use a locally-built version of jdk8.jar .
-    jdkShaHash = '3823f4b0a9d84d91d5f7575ad1f810cb7ac574c6'
+    jdkShaHash = 'local'
     if (rootProject.hasProperty("useLocalJdk")) {
         jdkShaHash = '3823f4b0a9d84d91d5f7575ad1f810cb7ac574c6'
     }

--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -2,9 +2,9 @@ ext {
     // See instructions for updating jdk8.jar at
     // https://github.com/typetools/annotated-libraries/blob/master/README.md .
     // Set jdkShaHash to 'local' to use a locally-built version of jdk8.jar .
-    jdkShaHash = 'local'
+    jdkShaHash = 'a5298dc50ff5cf3447d844472b8dd5ccadc34597'
     if (rootProject.hasProperty("useLocalJdk")) {
-        jdkShaHash = '3823f4b0a9d84d91d5f7575ad1f810cb7ac574c6'
+        jdkShaHash = 'local'
     }
 }
 sourceSets {

--- a/checker/jdk/determinism/src/java/util/HashSet.java
+++ b/checker/jdk/determinism/src/java/util/HashSet.java
@@ -102,7 +102,7 @@ public class HashSet<E>
      * Constructs a new, empty set; the backing <tt>HashMap</tt> instance has
      * default initial capacity (16) and load factor (0.75).
      */
-    public HashSet() {
+    public @OrderNonDet HashSet() {
         map = new HashMap<>();
     }
 
@@ -115,7 +115,7 @@ public class HashSet<E>
      * @param c the collection whose elements are to be placed into this set
      * @throws NullPointerException if the specified collection is null
      */
-    public @PolyDet HashSet(@PolyDet Collection<? extends E> c) {
+    public @OrderNonDet HashSet(@Det Collection<? extends E> c) {
         map = new HashMap<>(Math.max((int) (c.size()/.75f) + 1, 16));
         addAll(c);
     }
@@ -129,7 +129,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero, or if the load factor is nonpositive
      */
-    public @PolyDet HashSet(@PolyDet int initialCapacity, @PolyDet float loadFactor) {
+    public @OrderNonDet HashSet(@NonDet int initialCapacity, @NonDet float loadFactor) {
         map = new HashMap<>(initialCapacity, loadFactor);
     }
 
@@ -141,7 +141,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero
      */
-    public @PolyDet HashSet(@PolyDet int initialCapacity) {
+    public @OrderNonDet HashSet(@NonDet int initialCapacity) {
         map = new HashMap<>(initialCapacity);
     }
 
@@ -158,7 +158,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero, or if the load factor is nonpositive
      */
-    HashSet(int initialCapacity, float loadFactor, boolean dummy) {
+    @OrderNonDet HashSet(@NonDet int initialCapacity, @NonDet float loadFactor, @NonDet boolean dummy) {
         map = new LinkedHashMap<>(initialCapacity, loadFactor);
     }
 

--- a/checker/jdk/determinism/src/java/util/HashSet.java
+++ b/checker/jdk/determinism/src/java/util/HashSet.java
@@ -115,7 +115,7 @@ public class HashSet<E>
      * @param c the collection whose elements are to be placed into this set
      * @throws NullPointerException if the specified collection is null
      */
-    public @OrderNonDet HashSet(@Det Collection<? extends E> c) {
+    public @PolyDet HashSet(@PolyDet Collection<? extends E> c) {
         map = new HashMap<>(Math.max((int) (c.size()/.75f) + 1, 16));
         addAll(c);
     }
@@ -129,7 +129,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero, or if the load factor is nonpositive
      */
-    public @OrderNonDet HashSet(@NonDet int initialCapacity, @NonDet float loadFactor) {
+    public @PolyDet HashSet(@PolyDet int initialCapacity, @PolyDet float loadFactor) {
         map = new HashMap<>(initialCapacity, loadFactor);
     }
 
@@ -141,7 +141,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero
      */
-    public @OrderNonDet HashSet(@NonDet int initialCapacity) {
+    public @PolyDet HashSet(@PolyDet int initialCapacity) {
         map = new HashMap<>(initialCapacity);
     }
 
@@ -158,7 +158,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero, or if the load factor is nonpositive
      */
-    @OrderNonDet HashSet(@NonDet int initialCapacity, @NonDet float loadFactor, @NonDet boolean dummy) {
+    @PolyDet HashSet(@PolyDet int initialCapacity, @PolyDet float loadFactor, @PolyDet boolean dummy) {
         map = new LinkedHashMap<>(initialCapacity, loadFactor);
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -289,7 +289,7 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             if (isHashSet(annotatedTypeMirror)) {
                 AnnotationMirror explicitAnno = getNewClassAnnotation(node);
                 if (AnnotationUtils.areSame(explicitAnno, DET)
-                        || AnnotationUtils.areSameIgnoringValues(explicitAnno, POLYDET)) {
+                        || AnnotationUtils.areSameByName(explicitAnno, POLYDET)) {
                     checker.report(
                             Result.failure(
                                     DeterminismVisitor.INVALID_HASH_SET_CONSTRUCTOR_INVOCATION),
@@ -298,7 +298,7 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 }
                 if (annotatedTypeMirror.hasAnnotation(DET)) {
                     annotatedTypeMirror.replaceAnnotation(ORDERNONDET);
-                } else if (AnnotationUtils.areSameIgnoringValues(
+                } else if (AnnotationUtils.areSameByName(
                         annotatedTypeMirror.getAnnotationInHierarchy(NONDET), POLYDET)) {
                     annotatedTypeMirror.replaceAnnotation(NONDET);
                 }

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -271,8 +271,9 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         /**
-         * If node represents constructing a {@code @Det HashSet}, inserts {@code @OrderNonDet}
-         * instead.
+         * Reports an error if {@code node} represents explicitly constructing a {@code @Det
+         * HashSet}. If {@code @Det} annotation wasn't explicitly written, but the constructor would
+         * resolve to {@code @Det}, inserts {@code @OrderNonDet} instead.
          *
          * @param node a tree representing instantiating a class
          * @param annotatedTypeMirror the type to modify if it represents a {@code @Det HashSet}
@@ -288,6 +289,7 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                             Result.failure(
                                     DeterminismVisitor.INVALID_HASH_SET_CONSTRUCTOR_INVOCATION),
                             node);
+                    return super.visitNewClass(node, annotatedTypeMirror);
                 }
                 if (AnnotationUtils.areSame(
                         annotatedTypeMirror.getAnnotationInHierarchy(NONDET), DET)) {

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
@@ -50,6 +50,9 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
      */
     public static final @CompilerMessageKey String INVALID_UPPER_BOUND_TYPE_ARGUMENT_ARRAY =
             "invalid.upper.bound.on.type.argument.of.array";
+    /** Error message for expressions of the form "new @Det HashSet" */
+    public static final @CompilerMessageKey String INVALID_HASH_SET_CONSTRUCTOR_INVOCATION =
+            "invalid.hash.set.constructor.invocation";
     /**
      * The lower bound for exception parameters is {@code @Det}.
      *

--- a/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
@@ -10,4 +10,4 @@ invalid.type.on.conditional=conditional has type %s. It should be @Det for deter
 invalid.polydet.up=invalid to write @PolyDet("up") without a corresponding @PolyDet
 invalid.polydet.down=invalid to write @PolyDet("down") without a corresponding @PolyDet
 invalid.polydet.use=invalid to write @PolyDet("use") without a corresponding @PolyDet
-invalid.hash.set.constructor.invocation=invalid to write new @Det HashSet, HashSet is @OrderNonDet
+invalid.hash.set.constructor.invocation=invalid to write @Det or @PolyDet on HashSet, HashSet cannot be @Det

--- a/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
@@ -10,3 +10,4 @@ invalid.type.on.conditional=conditional has type %s. It should be @Det for deter
 invalid.polydet.up=invalid to write @PolyDet("up") without a corresponding @PolyDet
 invalid.polydet.down=invalid to write @PolyDet("down") without a corresponding @PolyDet
 invalid.polydet.use=invalid to write @PolyDet("use") without a corresponding @PolyDet
+invalid.hash.set.constructor.invocation=invalid to write new @Det HashSet, HashSet is @OrderNonDet

--- a/checker/tests/determinism/TestHashSet.java
+++ b/checker/tests/determinism/TestHashSet.java
@@ -1,0 +1,21 @@
+package determinism;
+
+import java.util.*;
+import org.checkerframework.checker.determinism.qual.*;
+
+class TestHashSet {
+    public static void testConstruct() {
+        // :: error: (assignment.type.incompatible)
+        @Det Set<String> s = new HashSet<String>();
+    }
+
+    public static void testIteration() {
+        Set<String> s = new HashSet<String>();
+        s.add("a");
+        s.add("b");
+        for (String str : s) {
+            // :: error: (argument.type.incompatible)
+            System.out.println(str);
+        }
+    }
+}

--- a/checker/tests/determinism/TestHashSet.java
+++ b/checker/tests/determinism/TestHashSet.java
@@ -4,22 +4,56 @@ import java.util.*;
 import org.checkerframework.checker.determinism.qual.*;
 
 class TestHashSet {
-    static void testConstruct() {
+    void testConstructDefault() {
         // :: error: (assignment.type.incompatible)
         @Det Set<String> s = new HashSet<String>();
     }
 
-    static void testConstructCollection(@Det List<String> collection) {
+    void testConstructCollection1(@Det List<@Det String> c) {
         // :: error: (argument.type.incompatible)
-        System.out.println(new HashSet<String>(collection));
+        System.out.println(new HashSet<@Det String>(c));
     }
 
-    static void testDetInvalid() {
+    void testConstructCollection2(@PolyDet List<@Det String> c) {
+        // :: error: (assignment.type.incompatible)
+        @PolyDet Set<@Det String> s = new HashSet<@Det String>(c);
+    }
+
+    void testConstructCollection3(@Det List<@Det String> c) {
+        @OrderNonDet Set<@Det String> s = new HashSet<@Det String>(c);
+    }
+
+    void testConstructCollection4(@PolyDet List<@Det String> c) {
+        // :: error: (assignment.type.incompatible)
+        @OrderNonDet Set<@Det String> s = new HashSet<@Det String>(c);
+    }
+
+    void testConstructCollection5(@PolyDet List<@Det String> c) {
+        // :: error: (assignment.type.incompatible)
+        @PolyDet Set<@Det String> s = new HashSet<@Det String>(c);
+    }
+
+    void testConstructCollection6(@PolyDet("up") List<@Det String> c) {
+        // :: error: (assignment.type.incompatible)
+        @PolyDet("up") Set<@Det String> s = new HashSet<@Det String>(c);
+    }
+
+    void testExplicitDet() {
         // :: error: (invalid.hash.set.constructor.invocation)
         @OrderNonDet Set<String> s = new @Det HashSet<String>();
     }
 
-    static void testIteration() {
+    void testExplicitPoly() {
+        // :: error: (invalid.hash.set.constructor.invocation)
+        @NonDet Set<String> s = new @PolyDet HashSet<String>();
+    }
+
+    void testExplicitPolyUp() {
+        // :: error: (invalid.hash.set.constructor.invocation)
+        @NonDet Set<String> s = new @PolyDet("up") HashSet<String>();
+    }
+
+    void testIteration() {
         Set<String> s = new HashSet<String>();
         for (String str : s) {
             // :: error: (argument.type.incompatible)

--- a/checker/tests/determinism/TestHashSet.java
+++ b/checker/tests/determinism/TestHashSet.java
@@ -15,8 +15,8 @@ class TestHashSet {
     }
 
     static void testDetInvalid() {
-        // :: error: (assignment.type.incompatible)
-        @Det Set<String> s = new @Det HashSet<String>();
+        // :: error: (invalid.hash.set.constructor.invocation)
+        @OrderNonDet Set<String> s = new @Det HashSet<String>();
     }
 
     static void testIteration() {

--- a/checker/tests/determinism/TestHashSet.java
+++ b/checker/tests/determinism/TestHashSet.java
@@ -4,15 +4,23 @@ import java.util.*;
 import org.checkerframework.checker.determinism.qual.*;
 
 class TestHashSet {
-    public static void testConstruct() {
+    static void testConstruct() {
         // :: error: (assignment.type.incompatible)
         @Det Set<String> s = new HashSet<String>();
     }
 
-    public static void testIteration() {
+    static void testConstructCollection(@Det List<String> collection) {
+        // :: error: (argument.type.incompatible)
+        System.out.println(new HashSet<String>(collection));
+    }
+
+    static void testDetInvalid() {
+        // :: error: (assignment.type.incompatible)
+        @Det Set<String> s = new @Det HashSet<String>();
+    }
+
+    static void testIteration() {
         Set<String> s = new HashSet<String>();
-        s.add("a");
-        s.add("b");
         for (String str : s) {
             // :: error: (argument.type.incompatible)
             System.out.println(str);

--- a/framework/tests/all-systems/Issue438.java
+++ b/framework/tests/all-systems/Issue438.java
@@ -4,7 +4,7 @@
 import java.util.HashSet;
 import java.util.List;
 
-@SuppressWarnings("determinism:invalid.type.on.conditional")
+@SuppressWarnings("determinism") // HashSet is @OrderNonDet
 public class Issue438 {
     boolean foo(List<String> list) {
         if (list.isEmpty()) {


### PR DESCRIPTION
Added the rule that if `new @Det HashSet` is written, an error is reported. If constructing a `HashSet` would be `@Det` for any other reason, e.g. constructing it with a `@Det Collection` parameter, the annotation `@OrderNonDet` is implicitly inserted.