### PR TITLE
Add check for annotated receiver; fixes #75

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -375,8 +375,16 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 // t.getReceiverType() is null for both "Object <init>()"
                 // and for static methods.
                 if (executableType.getReturnType().getAnnotations().isEmpty()) {
-                    if (executableType.getReceiverType() == null) {
-                        boolean unannotatedOrPolyDet = false;
+                    boolean unannotatedOrPolyDet = false;
+                    // First check receiver type. If it is unannotated or @PolyDet, don't check the
+                    // rest of the parameters.
+                    AnnotatedTypeMirror receiverType = executableType.getReceiverType();
+                    if (receiverType != null) {
+                        unannotatedOrPolyDet =
+                                receiverType.getAnnotations().isEmpty()
+                                        || receiverType.hasAnnotation(POLYDET);
+                    }
+                    if (!unannotatedOrPolyDet) {
                         for (AnnotatedTypeMirror paramType : executableType.getParameterTypes()) {
                             // The default is @PolyDet, so treat unannotated the same as @PolyDet.
                             // Note: "paramType.getAnnotations().isEmpty()" is true when there are

--- a/checker/tests/determinism/Issue75.java
+++ b/checker/tests/determinism/Issue75.java
@@ -1,0 +1,16 @@
+import org.checkerframework.checker.determinism.qual.*;
+
+public class Issue75 {
+    String detReceiver1(@Det Issue75 this) {
+        return null;
+    }
+
+    String detReceiver2(@Det Issue75 this, @Det String a) {
+        return null;
+    }
+
+    static void testInstanceMethodReturn(@Det Issue75 a, @Det String b) {
+        @Det String c = a.detReceiver1();
+        @Det String d = a.detReceiver2(b);
+    }
+}


### PR DESCRIPTION
This fixes Issue #75. The comment for `visitExecutable` indicates it was supposed to check the receiver type, but the receiver type was never examined.