### PR TITLE
Add @PolyDet("upDet") annotation and update HashSet and HashMap

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -2,7 +2,7 @@ ext {
     // See instructions for updating jdk8.jar at
     // https://github.com/typetools/annotated-libraries/blob/master/README.md .
     // Set jdkShaHash to 'local' to use a locally-built version of jdk8.jar .
-    jdkShaHash = '98547371cf0faf49fade320cbc5995d38e2f0e91'
+    jdkShaHash = 'd8d5ff6ad3448f11b24e6b3ba528cf7d25e58839'
     if (rootProject.hasProperty("useLocalJdk")) {
         jdkShaHash = 'local'
     }

--- a/checker/jdk/determinism/src/java/util/HashMap.java
+++ b/checker/jdk/determinism/src/java/util/HashMap.java
@@ -445,7 +445,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
      * @throws IllegalArgumentException if the initial capacity is negative
      *         or the load factor is nonpositive
      */
-    public @PolyDet HashMap(@PolyDet int initialCapacity, @PolyDet float loadFactor) {
+    public @PolyDet("upDet") HashMap(@PolyDet int initialCapacity, @PolyDet float loadFactor) {
         if (initialCapacity < 0)
             throw new IllegalArgumentException("Illegal initial capacity: " +
                     initialCapacity);
@@ -465,7 +465,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
      * @param  initialCapacity the initial capacity.
      * @throws IllegalArgumentException if the initial capacity is negative.
      */
-    public @PolyDet HashMap(@PolyDet int initialCapacity) {
+    public @PolyDet("upDet") HashMap(@PolyDet int initialCapacity) {
         this(initialCapacity, DEFAULT_LOAD_FACTOR);
     }
 
@@ -486,7 +486,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
      * @param   m the map whose mappings are to be placed in this map
      * @throws  NullPointerException if the specified map is null
      */
-    public @PolyDet HashMap(@PolyDet Map<? extends K, ? extends V> m) {
+    public @PolyDet("upDet") HashMap(@PolyDet Map<? extends K, ? extends V> m) {
         this.loadFactor = DEFAULT_LOAD_FACTOR;
         putMapEntries(m, false);
     }

--- a/checker/jdk/determinism/src/java/util/HashSet.java
+++ b/checker/jdk/determinism/src/java/util/HashSet.java
@@ -115,7 +115,7 @@ public class HashSet<E>
      * @param c the collection whose elements are to be placed into this set
      * @throws NullPointerException if the specified collection is null
      */
-    public @PolyDet HashSet(@PolyDet Collection<? extends E> c) {
+    public @PolyDet("upDet") HashSet(@PolyDet Collection<? extends E> c) {
         map = new HashMap<>(Math.max((int) (c.size()/.75f) + 1, 16));
         addAll(c);
     }
@@ -129,7 +129,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero, or if the load factor is nonpositive
      */
-    public @PolyDet HashSet(@PolyDet int initialCapacity, @PolyDet float loadFactor) {
+    public @PolyDet("upDet") HashSet(@PolyDet int initialCapacity, @PolyDet float loadFactor) {
         map = new HashMap<>(initialCapacity, loadFactor);
     }
 
@@ -141,7 +141,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero
      */
-    public @PolyDet HashSet(@PolyDet int initialCapacity) {
+    public @PolyDet("upDet") HashSet(@PolyDet int initialCapacity) {
         map = new HashMap<>(initialCapacity);
     }
 
@@ -158,7 +158,7 @@ public class HashSet<E>
      * @throws     IllegalArgumentException if the initial capacity is less
      *             than zero, or if the load factor is nonpositive
      */
-    @PolyDet HashSet(@PolyDet int initialCapacity, @PolyDet float loadFactor, @PolyDet boolean dummy) {
+    @PolyDet("upDet") HashSet(@PolyDet int initialCapacity, @PolyDet float loadFactor, @PolyDet boolean dummy) {
         map = new LinkedHashMap<>(initialCapacity, loadFactor);
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -52,6 +52,8 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     public final AnnotationMirror POLYDET_DOWN;
     /** The @PolyDet("use") annotation. */
     public final AnnotationMirror POLYDET_USE;
+    /** The @PolyDet("upDet") annotation. */
+    public final AnnotationMirror POLYDET_UPDET;
 
     /** The java.util.Set interface. */
     private final TypeMirror setInterfaceTypeMirror =
@@ -113,6 +115,7 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         POLYDET_UP = newPolyDet("up");
         POLYDET_DOWN = newPolyDet("down");
         POLYDET_USE = newPolyDet("use");
+        POLYDET_UPDET = newPolyDet("upDet");
 
         this.inputProperties = Collections.unmodifiableList(buildInputProperties());
 
@@ -837,6 +840,30 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             if (AnnotationUtils.areSame(subAnno, POLYDET_UP)
                     && AnnotationUtils.areSame(superAnno, POLYDET_DOWN)) {
                 return false;
+            }
+            if (AnnotationUtils.areSame(subAnno, POLYDET_UPDET)
+                    && AnnotationUtils.areSame(superAnno, POLYDET_UP)) {
+                return false;
+            }
+            if (AnnotationUtils.areSame(subAnno, POLYDET_UP)
+                    && AnnotationUtils.areSame(superAnno, POLYDET_UPDET)) {
+                return false;
+            }
+            if (AnnotationUtils.areSame(subAnno, POLYDET_UPDET)
+                    && AnnotationUtils.areSame(superAnno, POLYDET)) {
+                return false;
+            }
+            if (AnnotationUtils.areSame(subAnno, POLYDET)
+                    && AnnotationUtils.areSame(superAnno, POLYDET_UPDET)) {
+                return true;
+            }
+            if (AnnotationUtils.areSame(subAnno, POLYDET_UPDET)
+                    && AnnotationUtils.areSame(superAnno, POLYDET_DOWN)) {
+                return false;
+            }
+            if (AnnotationUtils.areSame(subAnno, POLYDET_DOWN)
+                    && AnnotationUtils.areSame(superAnno, POLYDET_UPDET)) {
+                return true;
             }
             if (AnnotationUtils.areSameByName(subAnno, POLYDET)) {
                 subAnno = POLYDET;

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -395,10 +395,7 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         }
 
         /**
-         * If {@code @Det} wasn't explicitly written on a {@code HashSet} or a {@code HashMap}, but
-         * the constructor would resolve to {@code @Det}, inserts {@code @OrderNonDet} instead.
-         *
-         * <p>If {@code @OrderNonDet} wasn't explicitly written on a {@code TreeSet} or a {@code
+         * If {@code @OrderNonDet} wasn't explicitly written on a {@code TreeSet} or a {@code
          * TreeMap}, but the constructor would resolve to {@code @OrderNonDet}, inserts {@code @Det}
          * instead.
          *
@@ -409,12 +406,7 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
          */
         @Override
         public Void visitNewClass(NewClassTree node, AnnotatedTypeMirror annotatedTypeMirror) {
-            if ((isHashSet(annotatedTypeMirror) && !isLinkedHashSet(annotatedTypeMirror))
-                    || (isHashMap(annotatedTypeMirror) && !isLinkedHashMap(annotatedTypeMirror))) {
-                if (annotatedTypeMirror.hasAnnotation(DET)) {
-                    annotatedTypeMirror.replaceAnnotation(ORDERNONDET);
-                }
-            } else if (isTreeSet(annotatedTypeMirror) || isTreeMap(annotatedTypeMirror)) {
+            if (isTreeSet(annotatedTypeMirror) || isTreeMap(annotatedTypeMirror)) {
                 if (annotatedTypeMirror.hasAnnotation(ORDERNONDET)) {
                     annotatedTypeMirror.replaceAnnotation(DET);
                 }

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismQualifierPolymorphism.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismQualifierPolymorphism.java
@@ -46,6 +46,7 @@ public class DeterminismQualifierPolymorphism extends DefaultQualifierPolymorphi
      * Replaces {@code @PolyDet("up")} with {@code @NonDet} if it resolves to {@code OrderNonDet}.
      * Replaces {@code @PolyDet("down")} with {@code @Det} if it resolves to {@code OrderNonDet}.
      * Replaces {@code @PolyDet("use")} with the same annotation that {@code @PolyDet} resolves to.
+     * Replaces {@code @PolyDet("upDet")} with {@code @OrderNonDet} if it resolves to {@code @Det}.
      *
      * @param type annotated type whose poly annotations are replaced
      * @param replacements mapping from polymorphic annotation to instantiation
@@ -68,7 +69,7 @@ public class DeterminismQualifierPolymorphism extends DefaultQualifierPolymorphi
             }
             if (quals.contains(factory.ORDERNONDET)
                     || replacements.get(factory.POLYDET).contains(factory.NONDET)) {
-                replaceForPolyUpOrDown(type, factory.NONDET);
+                replaceForPolyWithModifier(type, factory.NONDET);
             }
         } else if (type.hasAnnotation(factory.POLYDET_DOWN)) {
             AnnotationMirrorSet quals = replacements.get(factory.POLYDET);
@@ -77,7 +78,7 @@ public class DeterminismQualifierPolymorphism extends DefaultQualifierPolymorphi
             }
             if (quals.contains(factory.ORDERNONDET)
                     || replacements.get(factory.POLYDET).contains(factory.DET)) {
-                replaceForPolyUpOrDown(type, factory.DET);
+                replaceForPolyWithModifier(type, factory.DET);
             }
         } else if (type.hasAnnotation(factory.POLYDET_UPDET)) {
             AnnotationMirrorSet quals = replacements.get(factory.POLYDET);
@@ -85,7 +86,7 @@ public class DeterminismQualifierPolymorphism extends DefaultQualifierPolymorphi
                 type.replaceAnnotations(quals);
             }
             if (quals.contains(factory.DET)) {
-                replaceForPolyUpOrDown(type, factory.ORDERNONDET);
+                replaceForPolyWithModifier(type, factory.ORDERNONDET);
             }
         } else {
             for (Map.Entry<AnnotationMirror, AnnotationMirrorSet> pqentry :
@@ -108,7 +109,8 @@ public class DeterminismQualifierPolymorphism extends DefaultQualifierPolymorphi
      * @param type the polymorphic type to be replaced
      * @param replaceType the type to be replaced with
      */
-    private void replaceForPolyUpOrDown(AnnotatedTypeMirror type, AnnotationMirror replaceType) {
+    private void replaceForPolyWithModifier(
+            AnnotatedTypeMirror type, AnnotationMirror replaceType) {
         type.replaceAnnotation(replaceType);
         if (!(factory.isCollection(type)
                 || factory.isMap(type)

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismQualifierPolymorphism.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismQualifierPolymorphism.java
@@ -79,6 +79,14 @@ public class DeterminismQualifierPolymorphism extends DefaultQualifierPolymorphi
                     || replacements.get(factory.POLYDET).contains(factory.DET)) {
                 replaceForPolyUpOrDown(type, factory.DET);
             }
+        } else if (type.hasAnnotation(factory.POLYDET_UPDET)) {
+            AnnotationMirrorSet quals = replacements.get(factory.POLYDET);
+            if (quals.contains(factory.NONDET) || quals.contains(factory.ORDERNONDET)) {
+                type.replaceAnnotations(quals);
+            }
+            if (quals.contains(factory.DET)) {
+                replaceForPolyUpOrDown(type, factory.ORDERNONDET);
+            }
         } else {
             for (Map.Entry<AnnotationMirror, AnnotationMirrorSet> pqentry :
                     replacements.entrySet()) {

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
@@ -422,9 +422,9 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
     }
 
     /**
-     * Reports an error if {@code @PolyDet("up")}, {@code @PolyDet("down")} or
-     * {@code @PolyDet("use")} is written on a formal parameter or a return type and none of the
-     * formal parameters or the receiver has the type {@code @PolyDet}.
+     * Reports an error if {@code @PolyDet("up")}, {@code @PolyDet("down")},
+     * {@code @PolyDet("use")}, or {@code @PolyDet("upDet")} is written on a formal parameter or a
+     * return type and none of the formal parameters or the receiver has the type {@code @PolyDet}.
      */
     @Override
     public Void visitMethod(MethodTree node, Void p) {
@@ -448,6 +448,7 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
         boolean isPolyUpPresent = false;
         boolean isPolyDownPresent = false;
         boolean isPolyUsePresent = false;
+        boolean isPolyUpDetPresent = false;
         for (AnnotationMirror atm : polyAnnotations) {
             if (AnnotationUtils.areSame(atm, atypeFactory.POLYDET_UP)) {
                 isPolyUpPresent = true;
@@ -457,6 +458,9 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
             }
             if (AnnotationUtils.areSame(atm, atypeFactory.POLYDET_USE)) {
                 isPolyUsePresent = true;
+            }
+            if (AnnotationUtils.areSame(atm, atypeFactory.POLYDET_UPDET)) {
+                isPolyUpDetPresent = true;
             }
             if (AnnotationUtils.areSame(atm, atypeFactory.POLYDET)) {
                 isPolyPresent = true;
@@ -471,6 +475,9 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
             }
             if (isPolyUsePresent) {
                 checker.report(Result.failure("invalid.polydet.use"), node);
+            }
+            if (isPolyUpDetPresent) {
+                checker.report(Result.failure("invalid.polydet.updet"), node);
             }
         }
         return super.visitMethod(node, p);

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
@@ -544,8 +544,6 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
      * Reports an error if {@code newClassTree} represents explicitly constructing a
      *
      * <ol>
-     *   <li>{@code @Det HashSet}
-     *   <li>{@code @Det HashMap}
      *   <li>{@code @OrderNonDet TreeSet}
      *   <li>{@code @OrderNonDet TreeMap}
      * </ol>
@@ -564,26 +562,7 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
             NewClassTree newClassTree) {
         AnnotatedTypeMirror constructorResultType = constructor.getReturnType();
         AnnotationMirror explicitAnno = atypeFactory.getNewClassAnnotation(newClassTree);
-        if ((atypeFactory.isHashSet(constructorResultType)
-                        && !atypeFactory.isLinkedHashSet(constructorResultType))
-                || (atypeFactory.isHashMap(constructorResultType)
-                        && !atypeFactory.isLinkedHashMap(constructorResultType))) {
-            // There are two checks for @PolyDet. The first catches "new @PolyDet HashSet()"
-            // because in that case the annotation on constructorResultType is @OrderNonDet. The
-            // second catches instances where a @PolyDet collection was passed to the
-            // constructor.
-            if (AnnotationUtils.areSame(explicitAnno, atypeFactory.DET)
-                    || AnnotationUtils.areSameByName(explicitAnno, atypeFactory.POLYDET)
-                    || AnnotationUtils.areSameByName(
-                            constructorResultType.getAnnotationInHierarchy(atypeFactory.NONDET),
-                            atypeFactory.POLYDET)) {
-                checker.report(
-                        Result.failure(
-                                DeterminismVisitor.INVALID_COLLECTION_CONSTRUCTOR_INVOCATION,
-                                constructorResultType),
-                        newClassTree);
-            }
-        } else if (atypeFactory.isTreeSet(constructorResultType)
+        if (atypeFactory.isTreeSet(constructorResultType)
                 || atypeFactory.isTreeMap(constructorResultType)) {
             if (AnnotationUtils.areSame(explicitAnno, atypeFactory.ORDERNONDET)
                     || AnnotationUtils.areSameByName(explicitAnno, atypeFactory.POLYDET)

--- a/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
@@ -10,4 +10,5 @@ invalid.type.on.conditional=conditional has type %s. It should be @Det for deter
 invalid.polydet.up=invalid to write @PolyDet("up") without a corresponding @PolyDet
 invalid.polydet.down=invalid to write @PolyDet("down") without a corresponding @PolyDet
 invalid.polydet.use=invalid to write @PolyDet("use") without a corresponding @PolyDet
+invalid.polydet.updet=invalid to write @PolyDet("upDet") without a corresponding @PolyDet
 invalid.collection.constructor.invocation=invalid to create %s

--- a/checker/src/main/java/org/checkerframework/checker/determinism/qual/PolyDet.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/qual/PolyDet.java
@@ -27,7 +27,8 @@ import org.checkerframework.framework.qual.TypeUseLocation;
 @DefaultFor({TypeUseLocation.PARAMETER, TypeUseLocation.RETURN, TypeUseLocation.RECEIVER})
 public @interface PolyDet {
     /**
-     * Optionally, {@code @PolyDet} takes one of the three String values "up", "down" or "use".
+     * Optionally, {@code @PolyDet} takes one of the four String values "up", "down", "use", or
+     * "upDet".
      *
      * <p>If {@code @PolyDet} resolves to {@link OrderNonDet}, {@code @PolyDet("up")} gets replaced
      * by {@link NonDet}, and {@code @PolyDet("down")} by {@link Det}.
@@ -36,6 +37,9 @@ public @interface PolyDet {
      * {@code @PolyDet} without affecting the instantiation of {@code @PolyDet}. For example, a
      * method that is annotated as {@code void method_name (@PolyDet a, @PolyDet("use") b)} would
      * not allow the method invocation {@code method_name(@Det a, @NonDet b)}.
+     *
+     * <p>If {@code @PolyDet} resolves to {@link Det}, {@code @PolyDet("upDet"} gets replaced by
+     * {@link OrderNonDet}.
      */
     String value() default "";
 }

--- a/checker/tests/determinism/TestHashSet.java
+++ b/checker/tests/determinism/TestHashSet.java
@@ -15,7 +15,7 @@ class TestHashSet {
     }
 
     void testConstructCollection2(@PolyDet List<@Det String> c) {
-        // :: error: (invalid.collection.constructor.invocation)
+        // :: error: (assignment.type.incompatible)
         @PolyDet Set<@Det String> s = new HashSet<@Det String>(c);
     }
 
@@ -24,25 +24,22 @@ class TestHashSet {
     }
 
     void testConstructCollection6(@PolyDet("up") List<@Det String> c) {
-        // :: error: (invalid.collection.constructor.invocation)
+        // :: error: (assignment.type.incompatible)
         @PolyDet("up") Set<@Det String> s = new HashSet<@Det String>(c);
     }
 
     void testExplicitDet() {
-        // :: error: (invalid.collection.constructor.invocation) :: warning:
-        // (cast.unsafe.constructor.invocation)
+        // :: warning: (cast.unsafe.constructor.invocation)
         @OrderNonDet Set<String> s = new @Det HashSet<String>();
     }
 
     void testExplicitPoly() {
-        // :: error: (invalid.collection.constructor.invocation) :: error:
-        // constructor.invocation.invalid
+        // :: error: constructor.invocation.invalid
         new @PolyDet HashSet<String>();
     }
 
     void testExplicitPolyUp() {
-        // :: error: (invalid.collection.constructor.invocation) :: error:
-        // constructor.invocation.invalid
+        // :: error: constructor.invocation.invalid
         new @PolyDet("up") HashSet<String>();
     }
 

--- a/checker/tests/determinism/TestUpDet.java
+++ b/checker/tests/determinism/TestUpDet.java
@@ -1,0 +1,51 @@
+package determinism;
+
+import java.util.*;
+import org.checkerframework.checker.determinism.qual.*;
+
+class TestUpDet {
+    static @PolyDet("upDet") List<@Det String> retDetUp(@PolyDet List<@Det String> list) {
+        return new ArrayList<>();
+    }
+
+    public @Det List<@Det String> testReturnTypeResolve1(@Det List<@Det String> list) {
+        // :: error: (return.type.incompatible)
+        return retDetUp(list);
+    }
+
+    public @OrderNonDet List<@Det String> testReturnTypeResolve2(@Det List<@Det String> list) {
+        return retDetUp(list);
+    }
+
+    public @Det List<@Det String> testReturnTypeResolve3(@OrderNonDet List<@Det String> list) {
+        // :: error: (return.type.incompatible)
+        return retDetUp(list);
+    }
+
+    public @OrderNonDet List<@Det String> testReturnTypeResolve4(
+            @OrderNonDet List<@Det String> list) {
+        return retDetUp(list);
+    }
+
+    public @PolyDet("upDet") List<@Det String> testReturnTypeResolve5(
+            @PolyDet List<@Det String> list) {
+        return retDetUp(list);
+    }
+
+    public void testSubtypes(@PolyDet List<@Det String> l1, @PolyDet("down") List<@Det String> l2) {
+        @PolyDet("upDet") List<@Det String> a = l1;
+        @PolyDet("upDet") List<@Det String> b = l2;
+    }
+
+    public void testSubtypesInvalid(
+            @PolyDet("upDet") List<@Det String> l1, @PolyDet("up") List<@Det String> l2) {
+        // :: error: (assignment.type.incompatible)
+        @PolyDet("up") List<@Det String> a = l1;
+        // :: error: (assignment.type.incompatible)
+        @PolyDet List<@Det String> b = l1;
+        // :: error: (assignment.type.incompatible)
+        @PolyDet("down") List<@Det String> c = l1;
+        // :: error: (assignment.type.incompatible)
+        @PolyDet("upDet") List<@Det String> d = l2;
+    }
+}

--- a/docs/manual/determinism-checker.tex
+++ b/docs/manual/determinism-checker.tex
@@ -247,6 +247,12 @@ several enhancements to standard polymorphic qualifiers.
   \<@OrderNonDet>.
   ``\<up>'' refers to the direction in the qualifier hierarchy:
   \<@OrderNonDet> is changed to a higher qualifier that is a supertype of it.
+\item[\refqualclass{checker/determinism/qual}{PolyDet}\<("upDet")>]
+  Acts like \<@OrderNonDet> when the polymorphic qualifier is instantiated as
+  \<@Det>.
+  ``\<up>'' refers to the direction in the qualifier hierarchy and ``\<Det>''
+  refers to the annotation that is modified:
+  \<@Det> is changed to a higher qualifier that is a supertype of it.
 \end{description}
 
 Ordinarily, every occurrence of \<@PolyDet> is instantiated to the same
@@ -280,6 +286,20 @@ expressing the method behavior:
 @PolyDet("down") boolean add(     @PolyDet List<E> this, E e)
   @PolyDet("up") int hashCode(    @PolyDet List<E> this)
 \end{Verbatim}
+
+For an example of \refqualclass{checker/determinism/qual}{PolyDet}\<("upDet")>,
+consider the three versions of the \<HashSet> constructor that uses the elements
+of another \<Collection>:
+
+\begin{Verbatim}
+         @NonDet HashSet(      @NonDet Collection<? extends E> c)
+    @OrderNonDet HashSet( @OrderNonDet Collection<? extends E> c)
+    @OrderNonDet HashSet(         @Det Collection<? extends E> c)
+\end{Verbatim}
+
+Since a \<HashSet> can never be deterministic, the return type in the third case
+must be \<@OrderNonDet>. This is exactly what
+\refqualclass{checker/determinism/qual}{PolyDet}\<("upDet")> expresses.
 
 See the annotated JDK for more example uses of the annotations.
 

--- a/docs/manual/determinism-checker.tex
+++ b/docs/manual/determinism-checker.tex
@@ -207,21 +207,13 @@ For example, the following code type checks as expected:
     }
 \end{Verbatim}
 
-\subsectionAndLabel{HashSet}{determinism-hash-set}
-The class \code{HashSet} is special. Because iteration order is
-non-deterministic, it is impossible to construct a \code{@Det HashSet}.
-Accordingly, the checker has rules that give expressions of the form \code{new
-HashSet<T>(collection)} the correct type. The result of this expression will
-have the same determinism type as the collection. Except, if collection is
-\code{@Det} the result is \code{@OrderNonDet}.
-
-Because it impossible to construct a \code{@Det HashSet}, it is not allowed to
-explicitly write \code{new @Det HashSet} or \code{new @PolyDet HashSet}. There
-are only three valid instantiations of \code{HashSet}, and the desired type
-should be written explicitly. These are \code{@OrderNonDet HashSet<@Det T>},
-\code{@OrderNonDet HashSet<@OrderNonDet T>}, and \code{@NonDet HashSet<@NonDet
-T>}.
-
+\subsectionAndLabel{HashSet and HashMap}{determinism-hash-set}
+The \code{HashSet} and \code{HashMap} classes are special. Because iteration order is
+non-deterministic, it is impossible to construct a \code{@Det HashSet}
+or \code{@Det HashMap}.
+Accordingly, the return type of the \code{HashSet} and \code{Hashmap}
+constuctors are annotated as \code{@PolyDet("upDet")}. See
+Section~\ref{determinism-polymorphism-ordernondet}.
 
 \sectionAndLabel{Controlling polymorphism}{determinism-polymorphism}
 
@@ -234,7 +226,7 @@ The Determinism Checker makes
 several enhancements to standard polymorphic qualifiers.
 
 
-\subsectionAndLabel{Avoiding @OrderNonDet}{determinism-polymorphism-ordernondet}
+\subsectionAndLabel{@PolyDet Variants for Special Cases}{determinism-polymorphism-ordernondet}
 
 \begin{description}
 \item[\refqualclass{checker/determinism/qual}{PolyDet}\<("down")>]


### PR DESCRIPTION
This adds a new annotation, `@PolyDet("upDet")`. Its description is in the manual for this pull request itself. It represents the return type of the `HashSet` constructor, a type that cannot be `@Det`. That is, if `@PolyDet` would resolve to `@Det`, it instead resolves to `@OrderNonDet`.

This also updates the `HashSet` and `HashMap` classes in the JDK to use these new annotations. Also removes special support for them in the checker since the new annotation allows us to express their behavior without any extra code.