### PR TITLE
Correctly type (non-static) field accesses.

### DIFF
--- a/checker/jdk/determinism/src/java/lang/Class.java
+++ b/checker/jdk/determinism/src/java/lang/Class.java
@@ -3366,7 +3366,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 1.5
      */
     @SuppressWarnings("unchecked")
-    public @PolyDet T cast(@PolyDet Class<T> this, @PolyDet Object obj) {
+    public T cast(@PolyDet Class<T> this, @PolyDet Object obj) {
         if (obj != null && !isInstance(obj))
             throw new ClassCastException(cannotCastMsg(obj));
         return (T) obj;

--- a/checker/jdk/determinism/src/java/lang/Class.java
+++ b/checker/jdk/determinism/src/java/lang/Class.java
@@ -3366,7 +3366,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 1.5
      */
     @SuppressWarnings("unchecked")
-    public T cast(@PolyDet Class<T> this, @PolyDet Object obj) {
+    public @PolyDet T cast(@PolyDet Class<T> this, @PolyDet Object obj) {
         if (obj != null && !isInstance(obj))
             throw new ClassCastException(cannotCastMsg(obj));
         return (T) obj;

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -706,7 +706,11 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             AnnotatedTypeMirror type, AnnotatedTypeMirror owner, Element element) {
         super.postAsMemberOf(type, owner, element);
         if (element.getKind() == ElementKind.FIELD && !owner.hasAnnotation(DET)) {
-            type.replaceAnnotation(NONDET);
+            if (owner.hasAnnotation(POLYDET) && type.hasAnnotation(POLYDET)) {
+                // skip
+            } else {
+                type.replaceAnnotation(NONDET);
+            }
         }
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -710,23 +710,12 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         if (!isLHS
                 && owner.getKind() != TypeKind.ARRAY // array.length is dealt with elsewhere
                 && element.getKind() == ElementKind.FIELD
-                && !ElementUtils.isStatic(element)
-                && !owner.hasAnnotation(DET)) {
-            // For reads of non-static fields whose owner is not deterministic:
-            if (owner.hasAnnotation(POLYDET)) {
-                if (type.hasAnnotation(DET)) {
-                    // if owner is @PolyDet and field is @Det, change the type of the field to
-                    // @PolyDet.
-                    type.replaceAnnotation(POLYDET);
-                } else if (!type.hasAnnotation(POLYDET)) {
-                    // if owner is @PolyDet and field is not @PolyDet, change the type of the field
-                    // to @NonDet.
-                    type.replaceAnnotation(NONDET);
-                }
-            } else {
-                // if owner is not @Det nor @PolyDet, change the type of the field to @NonDet.
-                type.replaceAnnotation(NONDET);
-            }
+                && !ElementUtils.isStatic(element)) {
+            // The qualifier type of a field access is the LUB of the qualifier on the type of the
+            // field and the qualifier on the type of the access expression.
+            AnnotationMirror expressionAnno = owner.getEffectiveAnnotationInHierarchy(NONDET);
+            AnnotationMirror fieldAnno = type.getEffectiveAnnotationInHierarchy(NONDET);
+            type.replaceAnnotation(qualHierarchy.leastUpperBound(expressionAnno, fieldAnno));
         }
     }
 

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -706,8 +706,12 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             AnnotatedTypeMirror type, AnnotatedTypeMirror owner, Element element) {
         super.postAsMemberOf(type, owner, element);
         if (element.getKind() == ElementKind.FIELD && !owner.hasAnnotation(DET)) {
-            if (owner.hasAnnotation(POLYDET) && type.hasAnnotation(POLYDET)) {
-                // skip
+            if (owner.hasAnnotation(POLYDET)) {
+                if (type.hasAnnotation(DET)) {
+                    type.replaceAnnotation(POLYDET);
+                } else if (!type.hasAnnotation(POLYDET)) {
+                    type.replaceAnnotation(NONDET);
+                }
             } else {
                 type.replaceAnnotation(NONDET);
             }

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -705,7 +705,10 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     public void postAsMemberOf(
             AnnotatedTypeMirror type, AnnotatedTypeMirror owner, Element element) {
         super.postAsMemberOf(type, owner, element);
-        if (element.getKind() == ElementKind.FIELD && !owner.hasAnnotation(DET)) {
+        if (!isLHS
+                && element.getKind() == ElementKind.FIELD
+                && !ElementUtils.isStatic(element)
+                && !owner.hasAnnotation(DET)) {
             if (owner.hasAnnotation(POLYDET)) {
                 if (type.hasAnnotation(DET)) {
                     type.replaceAnnotation(POLYDET);
@@ -716,6 +719,17 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 type.replaceAnnotation(NONDET);
             }
         }
+    }
+
+    private boolean isLHS = false;
+
+    @Override
+    public AnnotatedTypeMirror getAnnotatedTypeLhs(Tree lhsTree) {
+        boolean oldIsLhs = isLHS;
+        isLHS = true;
+        AnnotatedTypeMirror type = super.getAnnotatedTypeLhs(lhsTree);
+        isLHS = oldIsLhs;
+        return type;
     }
 
     /** @return true if {@code subClass} is a subtype of {@code superClass} */

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -701,6 +701,15 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
         super.addComputedTypeAnnotations(tree, type, iUseFlow);
     }
 
+    @Override
+    public void postAsMemberOf(
+            AnnotatedTypeMirror type, AnnotatedTypeMirror owner, Element element) {
+        super.postAsMemberOf(type, owner, element);
+        if (element.getKind() == ElementKind.FIELD && !owner.hasAnnotation(DET)) {
+            type.replaceAnnotation(NONDET);
+        }
+    }
+
     /** @return true if {@code subClass} is a subtype of {@code superClass} */
     private boolean isSubClassOf(AnnotatedTypeMirror subClass, TypeMirror superClass) {
         return types.isSubtype(

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -705,23 +705,32 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     public void postAsMemberOf(
             AnnotatedTypeMirror type, AnnotatedTypeMirror owner, Element element) {
         super.postAsMemberOf(type, owner, element);
+        // For the field access of "element" whose type is "type" and whose access expression's type
+        // is "owner".
         if (!isLHS
-                && owner.getKind() != TypeKind.ARRAY
+                && owner.getKind() != TypeKind.ARRAY // array.length is dealt with elsewhere
                 && element.getKind() == ElementKind.FIELD
                 && !ElementUtils.isStatic(element)
                 && !owner.hasAnnotation(DET)) {
+            // For reads of non-static fields whose owner is not deterministic:
             if (owner.hasAnnotation(POLYDET)) {
                 if (type.hasAnnotation(DET)) {
+                    // if owner is @PolyDet and field is @Det, change the type of the field to
+                    // @PolyDet.
                     type.replaceAnnotation(POLYDET);
                 } else if (!type.hasAnnotation(POLYDET)) {
+                    // if owner is @PolyDet and field is not @PolyDet, change the type of the field
+                    // to @NonDet.
                     type.replaceAnnotation(NONDET);
                 }
             } else {
+                // if owner is not @Det nor @PolyDet, change the type of the field to @NonDet.
                 type.replaceAnnotation(NONDET);
             }
         }
     }
 
+    /** Is the type of a left hand side currently being computed? */
     private boolean isLHS = false;
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -706,6 +706,7 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
             AnnotatedTypeMirror type, AnnotatedTypeMirror owner, Element element) {
         super.postAsMemberOf(type, owner, element);
         if (!isLHS
+                && owner.getKind() != TypeKind.ARRAY
                 && element.getKind() == ElementKind.FIELD
                 && !ElementUtils.isStatic(element)
                 && !owner.hasAnnotation(DET)) {

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismTransfer.java
@@ -1,7 +1,6 @@
 package org.checkerframework.checker.determinism;
 
 import com.sun.source.tree.ClassTree;
-import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.tree.VariableTree;
 import java.util.Comparator;
@@ -75,9 +74,7 @@ public class DeterminismTransfer extends CFTransfer {
             UnderlyingAST underlyingAST, @Nullable List<LocalVariableNode> parameters) {
         CFStore initStore = super.initialStore(underlyingAST, parameters);
         if (underlyingAST.getKind() == Kind.METHOD) {
-
             CFGMethod method = (CFGMethod) underlyingAST;
-            MethodTree methodTree = method.getMethod();
             final ClassTree classTree = method.getClassTree();
             TypeMirror classType = TreeUtils.typeOf(classTree);
             Receiver receiver = new ThisReference(classType);

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismTransfer.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismTransfer.java
@@ -1,15 +1,29 @@
 package org.checkerframework.checker.determinism;
 
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import com.sun.source.tree.Tree;
+import com.sun.source.tree.VariableTree;
 import java.util.Comparator;
+import java.util.List;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Types;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.analysis.FlowExpressions;
+import org.checkerframework.dataflow.analysis.FlowExpressions.FieldAccess;
+import org.checkerframework.dataflow.analysis.FlowExpressions.Receiver;
+import org.checkerframework.dataflow.analysis.FlowExpressions.ThisReference;
 import org.checkerframework.dataflow.analysis.TransferInput;
 import org.checkerframework.dataflow.analysis.TransferResult;
+import org.checkerframework.dataflow.cfg.UnderlyingAST;
+import org.checkerframework.dataflow.cfg.UnderlyingAST.CFGMethod;
+import org.checkerframework.dataflow.cfg.UnderlyingAST.Kind;
+import org.checkerframework.dataflow.cfg.node.LocalVariableNode;
 import org.checkerframework.dataflow.cfg.node.MethodInvocationNode;
 import org.checkerframework.dataflow.cfg.node.Node;
 import org.checkerframework.framework.flow.CFAbstractAnalysis;
@@ -21,6 +35,8 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayTyp
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.ElementUtils;
+import org.checkerframework.javacutil.TreeUtils;
 import org.checkerframework.javacutil.TypesUtils;
 
 /**
@@ -45,6 +61,38 @@ public class DeterminismTransfer extends CFTransfer {
     /** Calls the superclass constructor. */
     public DeterminismTransfer(CFAbstractAnalysis<CFValue, CFStore, CFTransfer> analysis) {
         super(analysis);
+    }
+
+    /**
+     * Clear all non-static fields from the initial store.
+     *
+     * <p>Dataflow assumes that the type of a field access is at most the declared type of the
+     * field. This isn't true for the deterministic fields if they are accessed via a
+     * non-deterministic expression.
+     */
+    @Override
+    public CFStore initialStore(
+            UnderlyingAST underlyingAST, @Nullable List<LocalVariableNode> parameters) {
+        CFStore initStore = super.initialStore(underlyingAST, parameters);
+        if (underlyingAST.getKind() == Kind.METHOD) {
+
+            CFGMethod method = (CFGMethod) underlyingAST;
+            MethodTree methodTree = method.getMethod();
+            final ClassTree classTree = method.getClassTree();
+            TypeMirror classType = TreeUtils.typeOf(classTree);
+            Receiver receiver = new ThisReference(classType);
+            for (Tree member : classTree.getMembers()) {
+                if (member.getKind() == Tree.Kind.VARIABLE) {
+                    VariableElement e = TreeUtils.elementFromDeclaration((VariableTree) member);
+                    if (!ElementUtils.isStatic(e)) {
+                        TypeMirror fieldType = ElementUtils.getType(e);
+                        Receiver field = new FieldAccess(receiver, fieldType, e);
+                        initStore.clearValue(field);
+                    }
+                }
+            }
+        }
+        return initStore;
     }
 
     @Override

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
@@ -303,10 +303,10 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
                 super.commonAssignmentCheck(varTree, valueExp, errorKey);
             } else if (varTree.getKind() == Kind.ARRAY_ACCESS) {
                 checker.report(
-                        Result.failure(INVALID_ARRAY_ASSIGNMENT, exprAnno, varAnno), varTree);
+                        Result.failure(INVALID_ARRAY_ASSIGNMENT, varAnno, exprAnno), varTree);
             } else {
                 checker.report(
-                        Result.failure(INVALID_FIELD_ASSIGNMENT, exprAnno, varAnno), varTree);
+                        Result.failure(INVALID_FIELD_ASSIGNMENT, varAnno, exprAnno), varTree);
             }
         } else {
             super.commonAssignmentCheck(varTree, valueExp, errorKey);

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
@@ -261,6 +261,8 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
      *
      * The array access {@code x[i]} is flagged as an error.
      *
+     * <p>Also, reports error in case of invalid field access on the lhs of an assignment.
+     *
      * @param varTree the AST node for the lvalue
      * @param valueExp the AST node for the rvalue (the new value)
      * @param errorKey the error message to use if the check fails (must be a compiler message key)

--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismVisitor.java
@@ -1,10 +1,13 @@
 package org.checkerframework.checker.determinism;
 
 import com.sun.source.tree.*;
+import com.sun.source.tree.Tree.Kind;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.type.TypeKind;
@@ -21,6 +24,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedPrimitiv
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.util.AnnotatedTypes;
 import org.checkerframework.javacutil.AnnotationUtils;
+import org.checkerframework.javacutil.ElementUtils;
 import org.checkerframework.javacutil.TreeUtils;
 
 /** Visitor for the determinism type-system. */
@@ -47,6 +51,12 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
     /** Error message key for assignment to a deterministic array at a non-deterministic index. */
     public static final @CompilerMessageKey String INVALID_ARRAY_ASSIGNMENT =
             "invalid.array.assignment";
+
+    /**
+     * Error message key for assignment to a deterministic field via a non-deterministic expression.
+     */
+    public static final @CompilerMessageKey String INVALID_FIELD_ASSIGNMENT =
+            "invalid.field.assignment";
     /**
      * Error message key for collections whose type is a subtype of the upper bound of their type
      * arguments, or whose type is {@code @NonDet} with element type {@code @Det} or
@@ -124,7 +134,7 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
                             ((AnnotatedTypeVariable) argType).getUpperBound();
                     AnnotationMirror typevarAnnotation =
                             getUpperBound(atypeFactory, argTypeUpperBound);
-                    if (!isSubtype(
+                    if (!isSubtypeError(
                             typevarAnnotation,
                             baseAnnotation,
                             tree,
@@ -137,7 +147,7 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
                             ((AnnotatedTypeMirror.AnnotatedWildcardType) argType).getExtendsBound();
                     AnnotationMirror typevarAnnotation =
                             getUpperBound(atypeFactory, argTypeExtendsBound);
-                    if (!isSubtype(
+                    if (!isSubtypeError(
                             typevarAnnotation,
                             baseAnnotation,
                             tree,
@@ -258,19 +268,49 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
     @Override
     protected void commonAssignmentCheck(
             Tree varTree, ExpressionTree valueExp, @CompilerMessageKey String errorKey) {
-        if (varTree.getKind() == Tree.Kind.ARRAY_ACCESS) {
-            ArrayAccessTree arrTree = (ArrayAccessTree) varTree;
-            AnnotatedTypeMirror arrExprType =
-                    atypeFactory.getAnnotatedType(arrTree.getExpression());
-            AnnotatedArrayType arrType = (AnnotatedArrayType) arrExprType;
-            AnnotationMirror arrTopType = arrType.getAnnotationInHierarchy(atypeFactory.NONDET);
-            AnnotationMirror indexType =
-                    atypeFactory
-                            .getAnnotatedType(arrTree.getIndex())
-                            .getAnnotationInHierarchy(atypeFactory.NONDET);
-            isSubtype(indexType, arrTopType, varTree, INVALID_ARRAY_ASSIGNMENT);
+        AnnotatedTypeMirror expressionType;
+        switch (varTree.getKind()) {
+            case ARRAY_ACCESS:
+                Tree indexTree = ((ArrayAccessTree) varTree).getIndex();
+                expressionType = atypeFactory.getAnnotatedType(indexTree);
+                break;
+            case MEMBER_SELECT:
+            case IDENTIFIER:
+                Element field = TreeUtils.elementFromUse((ExpressionTree) varTree);
+                if (field.getKind() == ElementKind.FIELD && !ElementUtils.isStatic(field)) {
+                    expressionType = atypeFactory.getReceiverType((ExpressionTree) varTree);
+                } else {
+                    expressionType = null;
+                }
+                break;
+            case VARIABLE:
+                Element fieldDecl = TreeUtils.elementFromDeclaration((VariableTree) varTree);
+                if (fieldDecl.getKind() == ElementKind.FIELD && !ElementUtils.isStatic(fieldDecl)) {
+                    expressionType = atypeFactory.getSelfType(varTree);
+                } else {
+                    expressionType = null;
+                }
+                break;
+            default:
+                expressionType = null;
         }
-        super.commonAssignmentCheck(varTree, valueExp, errorKey);
+        if (expressionType != null) {
+            AnnotationMirror NONDET = atypeFactory.NONDET;
+            AnnotationMirror exprAnno = expressionType.getEffectiveAnnotationInHierarchy(NONDET);
+            AnnotatedTypeMirror varType = atypeFactory.getAnnotatedTypeLhs(varTree);
+            AnnotationMirror varAnno = varType.getEffectiveAnnotationInHierarchy(NONDET);
+            if (atypeFactory.getQualifierHierarchy().isSubtype(exprAnno, varAnno)) {
+                super.commonAssignmentCheck(varTree, valueExp, errorKey);
+            } else if (varTree.getKind() == Kind.ARRAY_ACCESS) {
+                checker.report(
+                        Result.failure(INVALID_ARRAY_ASSIGNMENT, exprAnno, varAnno), varTree);
+            } else {
+                checker.report(
+                        Result.failure(INVALID_FIELD_ASSIGNMENT, exprAnno, varAnno), varTree);
+            }
+        } else {
+            super.commonAssignmentCheck(varTree, valueExp, errorKey);
+        }
     }
 
     /**
@@ -483,7 +523,7 @@ public class DeterminismVisitor extends BaseTypeVisitor<DeterminismAnnotatedType
      * @return true if {@code subAnnotation} is a subtype of {@code superAnnotation}, false
      *     otherwise
      */
-    private boolean isSubtype(
+    private boolean isSubtypeError(
             AnnotationMirror subAnnotation,
             AnnotationMirror superAnnotation,
             Tree tree,

--- a/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/messages.properties
@@ -3,6 +3,7 @@ ordernondet.on.noncollection.and.nonarray=@OrderNonDet annotation is invalid for
 invalid.element.type=element type (%s) cannot be used with collection type (%s)
 invalid.array.component.type=component type (%s) cannot be used with array type (%s)
 invalid.array.assignment=cannot assign into %s array at %s index
+invalid.field.assignment=cannot assign into %s field via %s expression
 invalid.annotation.on.parameter=main method parameter cannot be annotated as %s
 invalid.upper.bound.on.type.argument=upper bound of type argument (%s) must be a subtype of the collection type (%s)
 invalid.upper.bound.on.type.argument.of.array=upper bound of type argument (%s) must be a subtype of the array type (%s)

--- a/checker/tests/determinism/Accesses.java
+++ b/checker/tests/determinism/Accesses.java
@@ -14,6 +14,15 @@ public class Accesses {
         return field; // ok
     }
 
+    @Override
+    public @PolyDet boolean equals(@PolyDet Accesses this, @PolyDet Object o) {
+        if (!(o instanceof Accesses)) {
+            return false;
+        }
+        Accesses other = (Accesses) o;
+        return this.field == other.field;
+    }
+
     static class Use {
         void method(@NonDet Accesses nonDet) {
             // :: error: (assignment.type.incompatible)

--- a/checker/tests/determinism/Accesses.java
+++ b/checker/tests/determinism/Accesses.java
@@ -1,0 +1,23 @@
+import org.checkerframework.checker.determinism.qual.Det;
+import org.checkerframework.checker.determinism.qual.NonDet;
+import org.checkerframework.checker.determinism.qual.PolyDet;
+
+public class Accesses {
+    public @Det Object field;
+
+    @Det Object method1(@PolyDet Accesses this) {
+        // :: error: (return.type.incompatible)
+        return field;
+    }
+
+    @Det Object method2(@Det Accesses this) {
+        return field; // ok
+    }
+
+    static class Use {
+        void method(@NonDet Accesses nonDet) {
+            // :: error: (assignment.type.incompatible)
+            @Det Object o1 = nonDet.field; // error
+        }
+    }
+}

--- a/checker/tests/determinism/Accesses.java
+++ b/checker/tests/determinism/Accesses.java
@@ -4,6 +4,7 @@ import org.checkerframework.checker.determinism.qual.PolyDet;
 
 public class Accesses {
     public @Det Object field;
+    public @PolyDet Object polyField;
 
     @Det Object method1(@PolyDet Accesses this) {
         // :: error: (return.type.incompatible)
@@ -20,7 +21,7 @@ public class Accesses {
             return false;
         }
         Accesses other = (Accesses) o;
-        return this.field == other.field;
+        return this.polyField == other.polyField;
     }
 
     static class Use {

--- a/checker/tests/determinism/FieldAccess.java
+++ b/checker/tests/determinism/FieldAccess.java
@@ -1,0 +1,112 @@
+import org.checkerframework.checker.determinism.qual.Det;
+import org.checkerframework.checker.determinism.qual.NonDet;
+import org.checkerframework.checker.determinism.qual.PolyDet;
+
+public class FieldAccess {
+    static @Det Object staticDetField = new Object();
+    public @Det Object detField = new Object();
+
+    void nonDetAccess(@NonDet FieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.detField;
+        @NonDet Object o2 = this.detField;
+        // :: error: (assignment.type.incompatible)
+        @PolyDet Object o3 = this.detField;
+    }
+
+    void polyAccess(@PolyDet FieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.detField;
+        @NonDet Object o2 = this.detField;
+        @PolyDet Object o3 = this.detField;
+    }
+
+    void detAccess(@Det FieldAccess this) {
+        @Det Object o = this.detField;
+    }
+
+    @Det Object detMethod(
+            @Det FieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        @Det Object o = this.detField;
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                // :: error: (assignment.type.incompatible)
+                detField = nonDetObj;
+                break;
+            case 1:
+                detField = detObj;
+                break;
+            case 2:
+                // :: error: (assignment.type.incompatible)
+                detField = polyDet;
+                break;
+            default:
+        }
+
+        return detField;
+    }
+
+    @PolyDet Object polyMethod(
+            @PolyDet FieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                // :: error: (invalid.field.assignment)
+                detField = nonDetObj;
+                break;
+            case 1:
+                // :: error: (invalid.field.assignment)
+                detField = detObj;
+                break;
+            case 2:
+                // :: error: (invalid.field.assignment)
+                detField = polyDet;
+                break;
+            default:
+        }
+        return detField;
+    }
+
+    @NonDet Object nonDetMethod(
+            @NonDet FieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                // :: error: (invalid.field.assignment)
+                detField = nonDetObj;
+                break;
+            case 1:
+                // :: error: (invalid.field.assignment)
+                detField = detObj;
+                break;
+            case 2:
+                // :: error: (invalid.field.assignment)
+                detField = polyDet;
+                break;
+            default:
+        }
+        return detField;
+    }
+
+    @Det FieldAccess fieldAccess;
+
+    void method(@NonDet FieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.fieldAccess.detField;
+        // :: error: (invalid.field.assignment)
+        this.fieldAccess.detField = new Object();
+    }
+}

--- a/checker/tests/determinism/NonDetFieldAccess.java
+++ b/checker/tests/determinism/NonDetFieldAccess.java
@@ -1,0 +1,107 @@
+import org.checkerframework.checker.determinism.qual.Det;
+import org.checkerframework.checker.determinism.qual.NonDet;
+import org.checkerframework.checker.determinism.qual.PolyDet;
+
+public class NonDetFieldAccess {
+    static @Det Object staticDetField = new Object();
+    public @NonDet Object nonDetField = new Object();
+
+    void nonDetAccess(@NonDet NonDetFieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.nonDetField;
+        @NonDet Object o2 = this.nonDetField;
+        // :: error: (assignment.type.incompatible)
+        @PolyDet Object o3 = this.nonDetField;
+    }
+
+    void polyAccess(@PolyDet NonDetFieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.nonDetField;
+        @NonDet Object o2 = this.nonDetField;
+        // :: error: (assignment.type.incompatible)
+        @PolyDet Object o3 = this.nonDetField;
+    }
+
+    void detAccess(@Det NonDetFieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.nonDetField;
+    }
+
+    @Det Object detMethod(
+            @Det NonDetFieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.nonDetField;
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                nonDetField = nonDetObj;
+                break;
+            case 1:
+                nonDetField = detObj;
+                break;
+            case 2:
+                nonDetField = polyDet;
+                break;
+            default:
+        }
+        // :: error: (return.type.incompatible)
+        return nonDetField;
+    }
+
+    @PolyDet Object polyMethod(
+            @PolyDet NonDetFieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                nonDetField = nonDetObj;
+                break;
+            case 1:
+                nonDetField = detObj;
+                break;
+            case 2:
+                nonDetField = polyDet;
+                break;
+            default:
+        }
+        // :: error: (return.type.incompatible)
+        return nonDetField;
+    }
+
+    @NonDet Object nonDetMethod(
+            @NonDet NonDetFieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                nonDetField = nonDetObj;
+                break;
+            case 1:
+                nonDetField = detObj;
+                break;
+            case 2:
+                nonDetField = polyDet;
+                break;
+            default:
+        }
+        return nonDetField;
+    }
+
+    @Det NonDetFieldAccess fieldAccess;
+
+    void method(@NonDet NonDetFieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.fieldAccess.nonDetField;
+        this.fieldAccess.nonDetField = new Object();
+    }
+}

--- a/checker/tests/determinism/PolyFieldAccess.java
+++ b/checker/tests/determinism/PolyFieldAccess.java
@@ -1,0 +1,107 @@
+import org.checkerframework.checker.determinism.qual.Det;
+import org.checkerframework.checker.determinism.qual.NonDet;
+import org.checkerframework.checker.determinism.qual.PolyDet;
+
+public class PolyFieldAccess {
+    static @Det Object staticDetField = new Object();
+    public @PolyDet Object polyField = new Object();
+
+    void nonDetAccess(@NonDet PolyFieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.polyField;
+        @NonDet Object o2 = this.polyField;
+        // :: error: (assignment.type.incompatible)
+        @PolyDet Object o3 = this.polyField;
+    }
+
+    void polyAccess(@PolyDet PolyFieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.polyField;
+        @NonDet Object o2 = this.polyField;
+        @PolyDet Object o3 = this.polyField;
+    }
+
+    void detAccess(@Det PolyFieldAccess this) {
+        @Det Object o = this.polyField;
+    }
+
+    @Det Object detMethod(
+            @Det PolyFieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        @Det Object o = this.polyField;
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                // :: error: (assignment.type.incompatible)
+                polyField = nonDetObj;
+                break;
+            case 1:
+                polyField = detObj;
+                break;
+            case 2:
+                // :: error: (assignment.type.incompatible)
+                polyField = polyDet;
+                break;
+            default:
+        }
+
+        return polyField;
+    }
+
+    @PolyDet Object polyMethod(
+            @PolyDet PolyFieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                // :: error: (assignment.type.incompatible)
+                polyField = nonDetObj;
+                break;
+            case 1:
+                polyField = detObj;
+                break;
+            case 2:
+                polyField = polyDet;
+                break;
+            default:
+        }
+        return polyField;
+    }
+
+    @NonDet Object nonDetMethod(
+            @NonDet PolyFieldAccess this,
+            @NonDet Object nonDetObj,
+            @Det Object detObj,
+            @PolyDet Object polyDet,
+            @Det int x) {
+        staticDetField = detObj;
+        switch (x) {
+            case 0:
+                polyField = nonDetObj;
+                break;
+            case 1:
+                polyField = detObj;
+                break;
+            case 2:
+                polyField = polyDet;
+                break;
+            default:
+        }
+        return polyField;
+    }
+
+    @Det PolyFieldAccess PolyFieldAccess;
+
+    void method(@NonDet PolyFieldAccess this) {
+        // :: error: (assignment.type.incompatible)
+        @Det Object o = this.PolyFieldAccess.polyField;
+        // :: error: (invalid.field.assignment)
+        this.PolyFieldAccess.polyField = new Object();
+    }
+}

--- a/checker/tests/determinism/TestClassAnnos.java
+++ b/checker/tests/determinism/TestClassAnnos.java
@@ -1,5 +1,6 @@
 import org.checkerframework.checker.determinism.qual.*;
 
+// @skip-test  I don't understand what this class is testing.
 public class TestClassAnnos {
     void test1() {
         Node nd = new Node();

--- a/framework/tests/all-systems/FieldAccess.java
+++ b/framework/tests/all-systems/FieldAccess.java
@@ -20,6 +20,7 @@ public class FieldAccess {
         T myClass = null;
     }
 
+    @SuppressWarnings("determinism:invalid.field.assignment")
     void test(Object o, MyGen raw) {
         // Raw type field access:
         raw.myClass.field = new Object();

--- a/framework/tests/all-systems/GenericCrazyBounds.java
+++ b/framework/tests/all-systems/GenericCrazyBounds.java
@@ -50,6 +50,7 @@ class RecImpl implements Rec<RecImpl> {}
 
 class SubRec extends RecImpl {}
 
+@SuppressWarnings("determinism:argument.type.incompatible")
 class CrazyGen2<TT extends MyList<EE>, EE extends MyMap<TT, TT>> {
     TT t2;
     EE e2;
@@ -65,6 +66,7 @@ class CrazyGen2<TT extends MyList<EE>, EE extends MyMap<TT, TT>> {
     }
 }
 
+@SuppressWarnings("determinism:argument.type.incompatible")
 class CrazyGen3<TTT extends MyList<TTT>, EEE extends MyMap<TTT, TTT>> {
     TTT t3;
     EEE e3;

--- a/framework/tests/all-systems/Issue263.java
+++ b/framework/tests/all-systems/Issue263.java
@@ -3,6 +3,7 @@
 
 abstract class Outer<T> {
 
+    @SuppressWarnings("determinism")
     public class Inner {
         private T t;
 

--- a/framework/tests/all-systems/Issue437.java
+++ b/framework/tests/all-systems/Issue437.java
@@ -5,6 +5,7 @@ abstract class I437Bar<T> {
     private final T t;
 
     class Norf {
+        @SuppressWarnings("determinism:return.type.incompatible")
         T getT() {
             return t;
         }


### PR DESCRIPTION
1. An error is issued if the type of an expression used to access a field is not a subtype of the field type.

2. The qualifier type of a field access is the LUB of the qualifier on the type of the field and the qualifier on the type of the access expression.