### PR TITLE
Update Iterator in JDK; fixes #149

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -2,7 +2,7 @@ ext {
     // See instructions for updating jdk8.jar at
     // https://github.com/typetools/annotated-libraries/blob/master/README.md .
     // Set jdkShaHash to 'local' to use a locally-built version of jdk8.jar .
-    jdkShaHash = '085a2a4aeed49947ff96cbea51fc3e4047f416c8'
+    jdkShaHash = '4d5a8032c3a3a3a74e734827ba480a66c50fa8ce'
     if (rootProject.hasProperty("useLocalJdk")) {
         jdkShaHash = 'local'
     }

--- a/checker/jdk/determinism/src/java/util/Iterator.java
+++ b/checker/jdk/determinism/src/java/util/Iterator.java
@@ -91,7 +91,7 @@ public interface Iterator<E> {
      *         been called after the last call to the {@code next}
      *         method
      */
-    default void remove(@PolyDet Iterator<E> this) {
+    default void remove(@PolyDet("noOrderNonDet") Iterator<E> this) {
         throw new UnsupportedOperationException("remove");
     }
 

--- a/checker/tests/determinism/TestIteratorRemove.java
+++ b/checker/tests/determinism/TestIteratorRemove.java
@@ -1,0 +1,38 @@
+package determinism;
+
+import java.util.*;
+import org.checkerframework.checker.determinism.qual.*;
+
+class TestIteratorRemove {
+    static void testRemoveDet(@Det List<@Det String> list) {
+        @OrderNonDet Iterator<@Det String> iter = list.iterator();
+        iter.next();
+        iter.remove();
+    }
+
+    static void testRemoveNonDet(@NonDet List<@NonDet String> list) {
+        @NonDet Iterator<@NonDet String> iter = list.iterator();
+        iter.next();
+        iter.remove();
+    }
+
+    static void testRemovePolyNoOND(@PolyDet("noOrderNonDet") List<@PolyDet String> list) {
+        @PolyDet("noOrderNonDet") Iterator<@PolyDet String> iter = list.iterator();
+        iter.next();
+        iter.remove();
+    }
+
+    static void testRemoveOrderNonDet(@OrderNonDet List<@Det String> list) {
+        @OrderNonDet Iterator<@Det String> iter = list.iterator();
+        iter.next();
+        // :: error: (method.invocation.invalid)
+        iter.remove();
+    }
+
+    static void testRemovePoly(@PolyDet List<@PolyDet String> list) {
+        @PolyDet Iterator<@PolyDet String> iter = list.iterator();
+        iter.next();
+        // :: error: (method.invocation.invalid)
+        iter.remove();
+    }
+}


### PR DESCRIPTION
Updates the `Iterator.remove` method in the JDK to remove unsoundness.