### PR TITLE
Modify Class.java; fixes #174

### DIFF
--- a/checker/build.gradle
+++ b/checker/build.gradle
@@ -2,7 +2,7 @@ ext {
     // See instructions for updating jdk8.jar at
     // https://github.com/typetools/annotated-libraries/blob/master/README.md .
     // Set jdkShaHash to 'local' to use a locally-built version of jdk8.jar .
-    jdkShaHash = 'c2fd4e1d81d9e075185d2e8e335720413924245f'
+    jdkShaHash = '43ef8769a2bdf39557c08e4db445310868cd547e'
     if (rootProject.hasProperty("useLocalJdk")) {
         jdkShaHash = 'local'
     }

--- a/checker/jdk/determinism/src/java/lang/Class.java
+++ b/checker/jdk/determinism/src/java/lang/Class.java
@@ -843,7 +843,7 @@ public final class Class<T> implements java.io.Serializable,
      *
      * @return an array of interfaces implemented by this class.
      */
-    public @PolyDet Class<?> @PolyDet("upDet") [] getInterfaces(@PolyDet Class<T> this) {
+    public @PolyDet Class<?> @PolyDet [] getInterfaces(@PolyDet Class<T> this) {
         ReflectionData<T> rd = reflectionData();
         if (rd == null) {
             // no cloning required
@@ -3432,7 +3432,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 1.8
      */
     @Override
-    public <A extends Annotation> A @OrderNonDet[] getAnnotationsByType(@PolyDet Class<T> this, @PolyDet Class<A> annotationClass) {
+    public <A extends Annotation> A @PolyDet("upDet") [] getAnnotationsByType(@PolyDet Class<T> this, @PolyDet Class<A> annotationClass) {
         Objects.requireNonNull(annotationClass);
 
         AnnotationData annotationData = annotationData();
@@ -3465,7 +3465,7 @@ public final class Class<T> implements java.io.Serializable,
      * @since 1.8
      */
     @Override
-    public <A extends Annotation> A @OrderNonDet[] getDeclaredAnnotationsByType(@PolyDet Class<T> this, @PolyDet Class<A> annotationClass) {
+    public <A extends Annotation> A @PolyDet("upDet") [] getDeclaredAnnotationsByType(@PolyDet Class<T> this, @PolyDet Class<A> annotationClass) {
         Objects.requireNonNull(annotationClass);
 
         return AnnotationSupport.getDirectlyAndIndirectlyPresent(annotationData().declaredAnnotations,

--- a/checker/tests/determinism/Issue174.java
+++ b/checker/tests/determinism/Issue174.java
@@ -1,4 +1,3 @@
-import java.util.*;
 import org.checkerframework.checker.determinism.qual.*;
 
 public class Issue174 {

--- a/checker/tests/determinism/Issue174.java
+++ b/checker/tests/determinism/Issue174.java
@@ -1,0 +1,13 @@
+import java.util.*;
+import org.checkerframework.checker.determinism.qual.*;
+
+public class Issue174 {
+    static void testGetInterfacesDet(@Det Class<?> c) {
+        @Det Class<?> @Det [] interfaces = c.getInterfaces();
+    }
+
+    static void testGetInterfacesNonDet(@NonDet Class<?> c) {
+        // :: error: (assignment.type.incompatible)
+        @Det Class<?> @Det [] interfaces = c.getInterfaces();
+    }
+}


### PR DESCRIPTION
Makes change mentioned in #174. Also fixes two other methods that were annotated as returning `@OrderNonDet` rather than `@PolyDet("upDet")`.