### PR TITLE
Update constructor defaults; fixes #182

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -786,21 +786,24 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
     @Override
     public void addComputedTypeAnnotations(Element elt, AnnotatedTypeMirror type) {
         if (elt.getKind() == ElementKind.PARAMETER) {
+            boolean isMain = false;
             if (elt.getEnclosingElement().getKind() == ElementKind.METHOD) {
                 ExecutableElement method = (ExecutableElement) elt.getEnclosingElement();
                 if (isMainMethod(method)) {
-                    if (!type.getAnnotations().isEmpty() && !type.hasAnnotation(DET)) {
-                        checker.reportError(
-                                elt,
-                                "invalid.annotation.on.parameter",
-                                type.getAnnotationInHierarchy(NONDET));
-                    }
-                    type.addMissingAnnotations(Collections.singleton(DET));
-                } else {
-                    defaultArrayComponentType(type, POLYDET);
+                    isMain = true;
                 }
-            } else if (elt.getEnclosingElement().getKind() == ElementKind.CONSTRUCTOR) {
+            }
+
+            if (isMain) {
+                if (!type.getAnnotations().isEmpty() && !type.hasAnnotation(DET)) {
+                    checker.reportError(
+                            elt,
+                            "invalid.annotation.on.parameter",
+                            type.getAnnotationInHierarchy(NONDET));
+                }
                 type.addMissingAnnotations(Collections.singleton(DET));
+            } else {
+                defaultArrayComponentType(type, POLYDET);
             }
         }
         if (elt.getKind() == ElementKind.LOCAL_VARIABLE) {

--- a/checker/tests/determinism/Issue182.java
+++ b/checker/tests/determinism/Issue182.java
@@ -1,0 +1,14 @@
+// test case for https://github.com/t-rasmud/checker-framework/issues/182
+
+import java.util.*;
+import org.checkerframework.checker.determinism.qual.*;
+
+public class Issue182 {
+    public Issue182(List<@PolyDet String> list) {
+        @PolyDet List<@PolyDet String> copy = list;
+    }
+
+    public Issue182(String[] arr) {
+        @PolyDet String @PolyDet [] arr2 = arr;
+    }
+}

--- a/docs/manual/determinism-checker.tex
+++ b/docs/manual/determinism-checker.tex
@@ -562,10 +562,12 @@ deterministic.  If it is be too restrictive for your program:
 
 The default annotation for most unannotated types is \<@PolyDet>.
 
-\subsectionAndLabel{Method signatures}{determinism-method-defaults}
+\subsectionAndLabel{Method and constructor signatures}{determinism-method-defaults}
 \begin{itemize}
 \item
   Formal parameter and return types default to \<@PolyDet>.
+\item
+  Constructor results default to \<@PolyDet>.
 \item
   If a formal parameter/return type is an array, its component type defaults to
   \<@PolyDet>.
@@ -579,7 +581,8 @@ The default annotation for most unannotated types is \<@PolyDet>.
   including all static fields, is \<@Det>.
 \end{itemize}
 
-These choices permit all possible arguments to an unannotated method.
+These choices permit all possible arguments to an unannotated method or
+constructor.
 
 \subsectionAndLabel{Local array and generic types}{determinism-array-defaults}
 According to the CLIMB to top rule (see Section~\ref{climb-to-top}), the default


### PR DESCRIPTION
It looks like there was code setting the default for constructor parameters to `@Det`, which was causing #182. Updated the defaults so that constructor parameters behave the same as method parameters.

Also, previously the constructor defaults were not clear in the manual, so I added that information.