### PR TITLE
Expand special case for Map get; fixes #193

### DIFF
--- a/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
+++ b/checker/src/main/java/org/checkerframework/checker/determinism/DeterminismAnnotatedTypeFactory.java
@@ -24,6 +24,7 @@ import org.checkerframework.framework.type.AnnotatedTypeMirror;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedArrayType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedDeclaredType;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedExecutableType;
+import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedTypeVariable;
 import org.checkerframework.framework.type.AnnotatedTypeMirror.AnnotatedWildcardType;
 import org.checkerframework.framework.type.QualifierHierarchy;
 import org.checkerframework.framework.type.poly.QualifierPolymorphism;
@@ -347,12 +348,16 @@ public class DeterminismAnnotatedTypeFactory extends BaseAnnotatedTypeFactory {
                 AnnotatedTypeMirror receiverType) {
             if ((isMapGet(node) || isMapGetOrDefault(node))
                     && receiverType.hasAnnotation(ORDERNONDET)
-                    && ((AnnotatedDeclaredType) receiverType)
-                            .getTypeArguments()
-                            .get(1)
-                            .hasAnnotation(DET)
                     && getAnnotatedType(node.getArguments().get(0)).hasAnnotation(DET)) {
-                methodInvocationType.replaceAnnotation(DET);
+                AnnotatedTypeMirror valueType =
+                        ((AnnotatedDeclaredType) receiverType).getTypeArguments().get(1);
+                if (valueType.hasAnnotation(DET)
+                        || (valueType.getKind() == TypeKind.TYPEVAR
+                                && ((AnnotatedTypeVariable) valueType)
+                                        .getUpperBound()
+                                        .hasAnnotation(DET))) {
+                    methodInvocationType.replaceAnnotation(DET);
+                }
             }
         }
 

--- a/checker/tests/determinism/Issue193.java
+++ b/checker/tests/determinism/Issue193.java
@@ -1,0 +1,9 @@
+import java.util.*;
+import org.checkerframework.checker.determinism.qual.*;
+
+public class Issue193 {
+    public <T extends @Det String> T callMapGet(
+            @OrderNonDet Map<@Det String, T> map, @Det String key) {
+        return map.get(key);
+    }
+}

--- a/docs/manual/determinism-checker.tex
+++ b/docs/manual/determinism-checker.tex
@@ -60,7 +60,7 @@ The Determinism type system uses the following type qualifiers (see Figure~\ref{
   a collection, iterator, or array will have the same elements in every execution, but in a
   possibly different order.  \<@OrderNonDet> may only be written on
   collection types.
-  An \<@OrderNonDet> Map indicates that the its keySet is \<@OrderNonDet>.
+  An \<@OrderNonDet> Map indicates that its keySet is \<@OrderNonDet>.
 \item[\refqualclass{checker/determinism/qual}{Det}] indicates that
   the expression evaluates to the same value (with respect to \<.equals()>) in all
   executions on the same machine; for a collection, iteration also yields the values in the same


### PR DESCRIPTION
The cause of #193 was a hardwired check for `Map.get` that checked for the value type of the `Map` being `@Det`. It didn't consider the case where the value was a type variable that extends `@Det`. This expands the criteria for that check.